### PR TITLE
Fix: Correct GitHub Actions workflow for multi-OS builds

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -294,9 +294,10 @@ jobs:
       - name: Build Electron app
         env:
           CSC_IDENTITY_AUTO_DISCOVERY: false
+        shell: pwsh # Ensure this step uses PowerShell
         run: |
           # Create electron-builder config without background requirement
-          cat > electron-builder.yml << EOF
+          $electronBuilderConfig = @"
           appId: com.whisperdesk.app
           productName: WhisperDesk
           mac:
@@ -305,15 +306,7 @@ jobs:
               - zip
             category: public.app-category.utilities
             darkModeSupport: true
-            contents:
-              - x: 130
-                y: 220
-                type: file
-                path: dist/mac/WhisperDesk.app
-              - x: 410
-                y: 220
-                type: link
-                path: /Applications
+          # The 'contents' section under 'mac:' has been removed.
           dmg:
             iconSize: 100
             contents:
@@ -328,13 +321,10 @@ jobs:
             window:
               width: 540
               height: 380
-          EOF
+          "@
+          Set-Content -Path electron-builder.yml -Value $electronBuilderConfig -Encoding UTF8
           
-          if [ "${{ matrix.arch }}" = "arm64" ]; then
-            npx electron-builder --mac --arm64 --publish=never --config electron-builder.yml
-          else
-            npx electron-builder --mac --x64 --publish=never --config electron-builder.yml
-          fi
+          npx electron-builder --win --x64 --publish=never --config electron-builder.yml
 
       # Upload artifacts
       - name: Upload Windows artifacts
@@ -515,15 +505,7 @@ jobs:
               - zip
             category: public.app-category.utilities
             darkModeSupport: true
-            contents:
-              - x: 130
-                y: 220
-                type: file
-                path: dist/mac/WhisperDesk.app
-              - x: 410
-                y: 220
-                type: link
-                path: /Applications
+          # The 'contents' section under 'mac:' has been removed.
           dmg:
             iconSize: 100
             contents:


### PR DESCRIPTION
This commit addresses several issues in the main.yml GitHub Actions workflow:

1.  **Windows Build PowerShell Compatibility:**
    - I modified the `build-windows` job to generate the `electron-builder.yml` file using PowerShell-compatible syntax (`Set-Content` instead of `cat << EOF`).
    - This resolves the `ParserError` previously encountered on Windows runners.

2.  **macOS `electron-builder` Configuration:**
    - I removed the deprecated `mac.contents` section from the `electron-builder.yml` configuration generated in both `build-macos` and `build-windows` jobs.
    - The DMG layout is correctly defined under `dmg.contents`.
    - This fixes the "Invalid configuration object" error related to `configuration.mac has an unknown property 'contents'` on macOS runners.

3.  **Windows Build Target Correction:**
    - I updated the `build-windows` job to correctly target Windows builds by changing the `npx electron-builder` command from `--mac` to `--win --x64`.
    - I removed the macOS-specific architecture switching logic for this command in the Windows job.

These changes should allow the workflow to successfully build for Windows, macOS, and Linux.