### PR TITLE
Fix: Remove explicit app path from dmg.contents in electron-builder

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -312,8 +312,7 @@ jobs:
             contents:
               - x: 130
                 y: 220
-                type: file
-                path: dist/mac/WhisperDesk.app
+                type: file # The 'path' key for this entry is removed
               - x: 410
                 y: 220
                 type: link
@@ -511,8 +510,7 @@ jobs:
             contents:
               - x: 130
                 y: 220
-                type: file
-                path: dist/mac/WhisperDesk.app
+                type: file # The 'path' key for this entry is removed
               - x: 410
                 y: 220
                 type: link


### PR DESCRIPTION
This commit updates the electron-builder configuration generated in the GitHub Actions workflow:

- In the `dmg.contents` section of `electron-builder.yml`, the explicit `path: dist/mac/WhisperDesk.app` for the main application file has been removed.

Electron-builder should automatically detect the application path. This change aims to resolve the "cannot find specified resource" error encountered during the macOS build process when creating the DMG, as the previously specified path might have been incorrect or conflicted with electron-builder's internal path resolution, especially considering different output directories for x64 and arm64 (`dist/mac/` vs `dist/mac-arm64/`).