### PR TITLE
Fix: Ensure Windows portable ZIP is generated in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -232,29 +232,36 @@ jobs:
         run: |
           # Create electron-builder config without background requirement
           $electronBuilderConfig = @"
-          appId: com.whisperdesk.app
-          productName: WhisperDesk
-          mac:
-            target:
-              - dmg
-              - zip
-            category: public.app-category.utilities
-            darkModeSupport: true
-          # The 'contents' section under 'mac:' has been removed.
-          dmg:
-            iconSize: 100
-            contents:
-              - x: 130
-                y: 220
-                type: file # The 'path' key for this entry is removed
-              - x: 410
-                y: 220
-                type: link
-                path: /Applications
-            window:
-              width: 540
-              height: 380
-          "@
+appId: com.whisperdesk.app
+productName: WhisperDesk
+mac:
+  target:
+    - dmg
+    - zip
+  category: public.app-category.utilities
+  darkModeSupport: true
+win:
+  target:
+    - target: nsis
+      arch: x64
+    - target: zip
+      arch: x64
+  icon: resources/icons/icon.ico
+  artifactName: \`${productName}`-\`${version}`-\`${os}`-\`${arch}`.`${ext}`
+dmg:
+  iconSize: 100
+  contents:
+    - x: 130
+      y: 220
+      type: file
+    - x: 410
+      y: 220
+      type: link
+      path: /Applications
+  window:
+    width: 540
+    height: 380
+"@
           Set-Content -Path electron-builder.yml -Value $electronBuilderConfig -Encoding UTF8
           
           npx electron-builder --win --x64 --publish=never --config electron-builder.yml


### PR DESCRIPTION
The GitHub Actions workflow for the Windows build creates a temporary electron-builder.yml configuration file. This commit updates that temporary configuration to explicitly include both 'nsis' (installer) and 'zip' (portable) targets for the Windows platform.

Previously, the Windows targets were expected to be picked up from the package.json configuration. However, you reported that the Windows ZIP file was missing from recent releases. Explicitly defining these targets in the temporary configuration used by the CI build ensures that electron-builder generates both the installer and the portable ZIP archive for Windows.

This change also copies the 'icon' and 'artifactName' properties from package.json's 'win' configuration into the temporary YAML to maintain consistency.