### PR TITLE
Add cancellation support for models and transcription

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -87,6 +87,9 @@ async function initializeModelManager() {
     services.modelManager.on('downloadError', (data) => {
       mainWindow?.webContents.send('model:downloadError', data);
     });
+    services.modelManager.on('downloadCancelled', (data) => {
+      mainWindow?.webContents.send('model:downloadCancelled', data);
+    });
     
     console.log('✅ Model Manager initialized');
   } catch (error) {
@@ -132,6 +135,10 @@ async function initializeTranscriptionService() {
     services.transcriptionService.on('start', (data) => {
       console.log('🎬 Transcription started');
       mainWindow?.webContents.send('transcription:start', data);
+    });
+    services.transcriptionService.on('cancelled', (data) => {
+      console.log('⏹️ Transcription cancelled');
+      mainWindow?.webContents.send('transcription:cancelled', data);
     });
     
     console.log('✅ Transcription Service initialized');
@@ -455,6 +462,7 @@ function setupIpcHandlers() {
   ipcMain.handle('model:download', (event, modelId) => services.modelManager.downloadModel(modelId));
   ipcMain.handle('model:delete', (event, modelId) => services.modelManager.deleteModel(modelId));
   ipcMain.handle('model:getInfo', (event, modelId) => services.modelManager.getModelInfo(modelId));
+  ipcMain.handle('model:cancelDownload', (event, modelId) => services.modelManager.cancelDownload(modelId));
 
   // Transcription - now using real service
   ipcMain.handle('transcription:getProviders', () => services.transcriptionService.getProviders());
@@ -473,6 +481,7 @@ function setupIpcHandlers() {
       throw error;
     }
   });
+  ipcMain.handle('transcription:stop', (event, transcriptionId) => services.transcriptionService.cancelTranscription(transcriptionId));
 
   // Settings - now using real service
   ipcMain.handle('settings:get', (event, key) => services.settingsService.get(key));

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -96,6 +96,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     download: createSafeIPC('model:download'),
     delete: createSafeIPC('model:delete'),
     getInfo: createSafeIPC('model:getInfo'),
+    cancelDownload: createSafeIPC('model:cancelDownload'),
     
     // Model events
     onDownloadQueued: createEventListener('model:downloadQueued'),
@@ -122,7 +123,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     onComplete: createEventListener('transcription:complete'),
     onError: createEventListener('transcription:error'),
     onResult: createEventListener('transcription:result'),
-    onStart: createEventListener('transcription:start')
+    onStart: createEventListener('transcription:start'),
+    onCancelled: createEventListener('transcription:cancelled')
   },
 
   // Audio service

--- a/src/renderer/whisperdesk-ui/src/App.jsx
+++ b/src/renderer/whisperdesk-ui/src/App.jsx
@@ -35,6 +35,7 @@ function AppStateProvider({ children }) {
     isTranscribing: false,
     progress: 0,
     progressMessage: '',
+    activeTranscriptionId: null,
     
     // Settings state
     selectedProvider: 'whisper-native',
@@ -81,7 +82,8 @@ function AppStateProvider({ children }) {
       isTranscribing: false,
       progress: 0,
       progressMessage: '',
-      lastTranscriptionResult: null
+      lastTranscriptionResult: null,
+      activeTranscriptionId: null
     })
   }
 
@@ -94,7 +96,8 @@ function AppStateProvider({ children }) {
       isTranscribing: false,
       progress: 0,
       progressMessage: '',
-      lastTranscriptionResult: null
+      lastTranscriptionResult: null,
+      activeTranscriptionId: null
     })
   }
 


### PR DESCRIPTION
## Summary
- support cancelling model downloads
- forward download cancel events from main to renderer
- expose cancel functionality via preload
- add stop button for transcription and handle cancellation events
- track active transcription ID in app state

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842c4b41ccc8321b8c5dc901659ea90