### PR TITLE
Add screen recording with pause and auto transcription

### DIFF
--- a/src/main/main.js
+++ b/src/main/main.js
@@ -497,6 +497,12 @@ function setupIpcHandlers() {
   ipcMain.handle('export:subtitle', (event, data, format) => services.exportService.exportSubtitle(data, format));
   ipcMain.handle('export:copy', (event, text) => services.exportService.copyToClipboard(text));
 
+  // Screen recorder
+  ipcMain.handle('screenRecorder:startRecording', (event, opts) => services.screenRecorder.startRecording(opts));
+  ipcMain.handle('screenRecorder:stopRecording', () => services.screenRecorder.stopRecording());
+  ipcMain.handle('screenRecorder:pauseRecording', () => services.screenRecorder.pauseRecording());
+  ipcMain.handle('screenRecorder:resumeRecording', () => services.screenRecorder.resumeRecording());
+
   // App operations
   ipcMain.handle('app:getVersion', () => app.getVersion());
   ipcMain.handle('app:restart', () => autoUpdater.quitAndInstall());

--- a/src/main/preload.js
+++ b/src/main/preload.js
@@ -133,10 +133,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     startRecording: createSafeIPC('audio:startRecording'),
     stopRecording: createSafeIPC('audio:stopRecording'),
     getWaveform: createSafeIPC('audio:getWaveform'),
-    
+
     // Audio events
     onData: createEventListener('audio:data'),
     onLevel: createEventListener('audio:level')
+  },
+
+  screenRecorder: {
+    startRecording: createSafeIPC('screenRecorder:startRecording'),
+    stopRecording: createSafeIPC('screenRecorder:stopRecording'),
+    pauseRecording: createSafeIPC('screenRecorder:pauseRecording'),
+    resumeRecording: createSafeIPC('screenRecorder:resumeRecording')
   },
 
   // Settings


### PR DESCRIPTION
## Summary
- extend screen recording service to support audio extraction, pause/resume and custom audio paths
- expose new screen recorder IPC APIs
- wire up IPC handlers in main process
- update transcription tab to choose audio save location, pause/resume, and start transcription automatically

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_68472405c87c83218cd391554a7dc76b