### PR TITLE
Fix Windows diarization build

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -110,6 +110,14 @@ jobs:
 
       - name: Add MSBuild to PATH
         uses: microsoft/setup-msbuild@v2
+      - name: Install jsoncpp (vcpkg)
+        shell: pwsh
+        run: |
+          $vcpkgRoot = "C:/vcpkg"
+          & "$vcpkgRoot/vcpkg.exe" install jsoncpp:x64-windows
+          echo "VCPKG_ROOT=$vcpkgRoot" >> $env:GITHUB_ENV
+          echo "VCPKG_DEFAULT_TRIPLET=x64-windows" >> $env:GITHUB_ENV
+          echo "CMAKE_TOOLCHAIN_FILE=$vcpkgRoot/scripts/buildsystems/vcpkg.cmake" >> $env:GITHUB_ENV
 
       - name: Update main package.json version
         shell: pwsh

--- a/README.md
+++ b/README.md
@@ -94,7 +94,11 @@ You can use the automated setup scripts or follow the manual steps:
     npm run build:whisper
     ```
     *(Refer to `tools/setup/build-whisper.sh` for Unix or `tools/setup/compile-whisper-windows.ps1` for Windows for more details on the native build process).*
-4.  **Download a Model:**
+4.  **Windows: Install jsoncpp via vcpkg:**
+    ```powershell
+    vcpkg install jsoncpp:x64-windows
+    ```
+5.  **Download a Model:**
     Manually download a model if needed (the application can also do this via the UI).
     ```bash
     mkdir -p ~/.config/whisperdesk/models


### PR DESCRIPTION
## Summary
- install `jsoncpp` via vcpkg in Windows workflow
- document Windows jsoncpp step in manual build instructions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a89aff7388321be95c9ba4d085e24