### PR TITLE
Fix Windows ONNX model path

### DIFF
--- a/src/native/diarization/speaker-embedder.cpp
+++ b/src/native/diarization/speaker-embedder.cpp
@@ -33,7 +33,12 @@ bool SpeakerEmbedder::initialize(const std::string& model_path, int sample_rate,
         target_length_ = static_cast<size_t>(target_duration * sample_rate);
         
         // Load ONNX model
+#ifdef _WIN32
+        std::wstring w_model_path(model_path.begin(), model_path.end());
+        session_ = std::make_unique<Ort::Session>(env_, w_model_path.c_str(), session_options_);
+#else
         session_ = std::make_unique<Ort::Session>(env_, model_path.c_str(), session_options_);
+#endif
         
         // Get output shape to determine embedding dimension
         auto output_info = session_->GetOutputTypeInfo(0);

--- a/src/native/diarization/speaker-segmenter.cpp
+++ b/src/native/diarization/speaker-segmenter.cpp
@@ -35,7 +35,12 @@ bool SpeakerSegmenter::initialize(const std::string& model_path, int sample_rate
         window_size_ = 51200;  // Exactly what pyannote segmentation-3.0 expects
         hop_size_ = 25600;     // 50% overlap
         
+#ifdef _WIN32
+        std::wstring w_model_path(model_path.begin(), model_path.end());
+        session_ = std::make_unique<Ort::Session>(env_, w_model_path.c_str(), session_options_);
+#else
         session_ = std::make_unique<Ort::Session>(env_, model_path.c_str(), session_options_);
+#endif
         
         if (verbose_) {
             auto input_count = session_->GetInputCount();


### PR DESCRIPTION
## Summary
- handle Windows wide-character file paths when creating ONNX Runtime sessions

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9a8d02f08321917804250e533a87