### PR TITLE
Fix duplicate Windows helper definition

### DIFF
--- a/src/native/diarization/include/utils.h
+++ b/src/native/diarization/include/utils.h
@@ -5,6 +5,23 @@
 #include <string>
 #include <map>
 
+#ifdef _WIN32
+#include <windows.h>
+
+// Helper used by multiple translation units
+static inline std::wstring string_to_wstring(const std::string& str) {
+    if (str.empty()) return std::wstring();
+
+    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0],
+                                          static_cast<int>(str.size()),
+                                          NULL, 0);
+    std::wstring wstr(size_needed, 0);
+    MultiByteToWideChar(CP_UTF8, 0, &str[0], static_cast<int>(str.size()),
+                        &wstr[0], size_needed);
+    return wstr;
+}
+#endif
+
 // Forward declarations
 struct AudioSegment;
 struct DiarizeOptions;

--- a/src/native/diarization/speaker-embedder.cpp
+++ b/src/native/diarization/speaker-embedder.cpp
@@ -7,16 +7,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-
-// Helper function to convert std::string to std::wstring on Windows
-std::wstring string_to_wstring(const std::string& str) {
-    if (str.empty()) return std::wstring();
-    
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
-    std::wstring wstr(size_needed, 0);
-    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstr[0], size_needed);
-    return wstr;
-}
 #endif
 
 SpeakerEmbedder::SpeakerEmbedder(bool verbose)

--- a/src/native/diarization/speaker-segmenter.cpp
+++ b/src/native/diarization/speaker-segmenter.cpp
@@ -8,16 +8,6 @@
 
 #ifdef _WIN32
 #include <windows.h>
-
-// Helper function to convert std::string to std::wstring on Windows
-std::wstring string_to_wstring(const std::string& str) {
-    if (str.empty()) return std::wstring();
-    
-    int size_needed = MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), NULL, 0);
-    std::wstring wstr(size_needed, 0);
-    MultiByteToWideChar(CP_UTF8, 0, &str[0], (int)str.size(), &wstr[0], size_needed);
-    return wstr;
-}
 #endif
 
 SpeakerSegmenter::SpeakerSegmenter(bool verbose)


### PR DESCRIPTION
## Summary
- centralize `string_to_wstring` into utils header
- drop duplicate definitions from speaker source files

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684a9f32254883219ae0e941b5eadb96